### PR TITLE
[auto] security: update hono to >=4.12.7 (path traversal fix)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@ dist/
 .wrangler/
 .dev.vars
 .mcp.json
+# cc-taskrunner worktree protection
+C:*
+node_modules/
+.pnpm-store/
+__pycache__/

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@cloudflare/workers-oauth-provider": "^0.2.4",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "agents": "^0.7.2",
+        "hono": "^4.12.8",
         "zod": "^3.25.0"
       },
       "devDependencies": {
@@ -2787,9 +2788,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.5",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
-      "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
+      "version": "4.12.8",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
+      "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/package.json
+++ b/package.json
@@ -11,9 +11,10 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.27.1",
     "@cloudflare/workers-oauth-provider": "^0.2.4",
+    "@modelcontextprotocol/sdk": "^1.27.1",
     "agents": "^0.7.2",
+    "hono": "^4.12.8",
     "zod": "^3.25.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Autonomous Task

**Task ID**: `07281c51-5b9d-4c48-8d39-349214061c7f`
**Authority**: auto_safe
**Exit code**: 0

## Task Prompt
Update hono to >=4.12.7 to fix GHSA-q5qw-h33p-qvwr (serveStatic path traversal, CVSS 7.5) and 3 other CVEs.

1. Run `npm install hono@latest`
2. Run typecheck to verify no breaking changes
3. Commit with: "fix: update hono to latest (GHSA-q5qw-h33p-qvwr path traversal fix)"

This is a semver-compatible patch bump — should be zero code changes needed.

TASK_COMPLETE when committed and typecheck passes.

## Result Summary
Hono updated from previous version to 4.12.8, typecheck passes, committed.

TASK_COMPLETE

---
Generated by AEGIS task runner. Review before merging.